### PR TITLE
Refactor: Correct Narramorph content parsing and selection logic

### DIFF
--- a/docs/Narramorph-Implementation-Plan.md
+++ b/docs/Narramorph-Implementation-Plan.md
@@ -1,3 +1,7 @@
+---
+**Note (2025-06-08):** This implementation plan has been largely completed. The core Narramorph functionality, including multi-state content based on visit counts and the transformation engine, is now part of the prototype. Some minor deviations from this original plan (such as the exact delimiter used) were made during implementation and have been addressed in the codebase. This document serves as a record of the initial plan.
+---
+
 # Narramorph Implementation Plan
 
 This document outlines the architectural design and implementation plan for the Narramorph feature in the "Eternal Return of the Digital Self" project.

--- a/src/store/slices/nodesSlice.ts
+++ b/src/store/slices/nodesSlice.ts
@@ -215,9 +215,9 @@ export const loadNodeContent = createAsyncThunk(
       const text = await response.text();
 
       const content: NarramorphContent = {};
-      const parts = text.split(/---t\[(\d+)\]/);
+      const parts = text.split(/---\[(\d+)\]/);
 
-      if (parts.length > 0 && !text.startsWith('---t[')) {
+      if (parts.length > 0 && !text.startsWith('---[')) {
           content[0] = parts[0].trim();
       }
 
@@ -271,7 +271,8 @@ const nodesSlice = createSlice({
           const availableCounts = Object.keys(node.content)
             .map(Number)
             .sort((a, b) => b - a); // Sort descending
-          const bestMatch = availableCounts.find(count => node.visitCount >= count);
+          const lookupKey = Math.max(0, node.visitCount - 1);
+          const bestMatch = availableCounts.find(count => lookupKey >= count);
           if (bestMatch !== undefined) {
             // Store the base content (without transformations)
             node.currentContent = node.content[bestMatch];
@@ -323,7 +324,8 @@ const nodesSlice = createSlice({
           .map(Number)
           .sort((a, b) => b - a); // Sort descending
         
-        const bestMatch = availableCounts.find(count => node.visitCount >= count);
+        const lookupKey = Math.max(0, node.visitCount - 1);
+        const bestMatch = availableCounts.find(count => lookupKey >= count);
         if (bestMatch !== undefined) {
           const baseContent = node.content[bestMatch];
           
@@ -441,7 +443,8 @@ const nodesSlice = createSlice({
           const availableCounts = Object.keys(node.content)
               .map(Number)
               .sort((a, b) => b - a); // Sort descending
-          const bestMatch = availableCounts.find(count => node.visitCount >= count);
+          const lookupKey = Math.max(0, node.visitCount - 1);
+          const bestMatch = availableCounts.find(count => lookupKey >= count);
           if (bestMatch !== undefined) {
               node.currentContent = node.content[bestMatch];
           } else {


### PR DESCRIPTION
This commit addresses issues in the Narramorph feature:

1.  **Delimiter Parsing:** I modified `loadNodeContent` in `nodesSlice.ts` to correctly parse `---[visit_count]` delimiters used in the core narrative markdown files. The previous logic expected `---t[visit_count]`, which misaligned with the actual content files, preventing multi-state content from loading correctly.

2.  **Content Selection Logic:** I refined the logic in `nodesSlice.ts` (within `visitNode`, `loadNodeContent.fulfilled`, and `evaluateTransformations`) for selecting the appropriate content from `NarramorphContent` based on the node's `visitCount`. The new logic correctly maps `visitCount` (e.g., 1st visit, 2nd visit) to the corresponding content state keys (e.g., 0, 1).

Additionally, I updated the `docs/Narramorph-Implementation-Plan.md` to note that the plan has been largely implemented and the codebase reflects its current state.